### PR TITLE
fix(deploy): add redirect logic for GitHub Pages routing

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="Echoboard: A lightweight dashboard for tracking personal counters, GitHub activity, and daily summary notes."
+    />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>Echoboard</title>
+
+    <!-- START of code to ADD -->
+    <!--
+      This script is a workaround for handling client-side routing with GitHub Pages.
+      It captures the URL the user was trying to access and redirects them back
+      to the root of the app, passing the original path as a query parameter.
+    -->
+    <script type="text/javascript">
+      // Get the current URL path (e.g., /echoboard/user/robert)
+      var path = window.location.pathname
+
+      // Check if the path is from a subdirectory (like on GitHub Pages)
+      var segment = path.split('/')[1]
+
+      // Redirect to the root, passing the path in a query string
+      window.location.replace(
+        '/' + segment + '/?path=' + path.substring(1 + segment.length)
+      )
+    </script>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,13 @@
 
 import React, { useEffect, useReducer, useCallback } from 'react'
 // 1. Import routing components
-import { Routes, Route, useNavigate, useParams } from 'react-router-dom'
+import {
+  Routes,
+  Route,
+  useNavigate,
+  useParams,
+  useLocation,
+} from 'react-router-dom'
 
 // Import our new page components
 import LoginPage from './LoginPage'
@@ -119,6 +125,8 @@ function App() {
 
   // 2. Initialize the navigate function
   const navigate = useNavigate()
+
+  const location = useLocation()
 
   // This function is now ASYNCHRONOUS to work better with navigation
   // Wrap this function in useCallback
@@ -261,6 +269,21 @@ function App() {
     }
     fetchPRsForUser()
   }, [user])
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search)
+    const redirectPath = params.get('path')
+
+    if (redirectPath) {
+      // If a path was passed in the query, navigate to it,
+      // replacing the current history entry.
+      navigate('/' + redirectPath, { replace: true })
+    }
+    // The empty dependency array [] ensures this runs only once on mount.
+    // We disable the ESLint warning because we intentionally want this effect
+    // to not re-run when navigate or location change after the initial load.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const groupedUsers = userList.reduce((acc, u) => {
     if (!acc[u.team]) acc[u.team] = []


### PR DESCRIPTION
This PR implements the standard workaround for handling deep links with React Router on GitHub Pages. 
It adds a 404.html redirect page and logic in App.js to handle the redirected path. 
This resolves the 404 errors when accessing user dashboard URLs directly.