### PR TITLE
fix(profile): ensure empty github username is saved as null

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -197,7 +197,7 @@ function App() {
         email: formData.email,
         team: formData.team,
         role: formData.role,
-        github_username: formData.github_username,
+        github_username: formData.github_username || null,
       })
       .eq('id', user.id)
       .select() // Use .select() to get the updated row back from the database


### PR DESCRIPTION
### Description

This pull request resolves a critical bug that prevented user profiles from being updated under specific conditions. The error occurred when trying to save a profile with an empty GitHub username if another user in the database already had an empty username, due to a unique constraint violation.

### Key Changes:

*   **`App.js`:**
    *   The `handleProfileUpdate` function has been modified. It now explicitly converts an empty string (`''`) for the `github_username` field into a `null` value before sending the update to Supabase. This correctly handles the database's unique constraint, which allows multiple `null` values but not multiple empty strings.

### How to Test:

1.  Identify two users who do **not** have a GitHub username.
2.  Log in as the first user and navigate to the dashboard.
3.  In the "Edit Profile" widget, make a change to any field (e.g., Display Name) and click "Save Changes".
4.  **Expected Result:** The profile should save successfully without any errors.
5.  Log out and log in as the second user.
6.  Repeat step 3 (make a change and save).
7.  **Expected Result:** The profile should save successfully, which confirms the fix is working correctly.