### PR TITLE
feat(ui): add back-to-top scroll button

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import {
 import LoginPage from './LoginPage'
 import DashboardPage from './DashboardPage'
 import ThemeToggle from './ThemeToggle'
+import BackToTopButton from './BackToTopButton'
 import supabase from './supabaseClient'
 import { fetchPullRequests } from './githubApi'
 import { useToast } from './ToastContext'
@@ -383,6 +384,8 @@ function App() {
           }
         />
       </Routes>
+
+      <BackToTopButton />
     </div>
   )
 }

--- a/src/BackToTopButton.css
+++ b/src/BackToTopButton.css
@@ -1,0 +1,52 @@
+/* src/BackToTopButton.css */
+
+.back-to-top-button {
+  /* Positioning */
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 1000;
+
+  /* Appearance */
+  background-color: var(--color-surface);
+  color: var(--color-primary);
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  width: 48px; /* A bit larger for easy clicking */
+  height: 48px;
+  box-shadow: var(--shadow-sm);
+
+  /* Flexbox for centering the icon inside */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  /* Interaction */
+  cursor: pointer;
+  transition: all 0.3s ease-in-out;
+
+  /* Initial state: hidden */
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(20px);
+}
+
+.back-to-top-button.visible {
+  /* Visible state: shown */
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.back-to-top-button:hover {
+  background-color: var(--color-primary);
+  color: #ffffff; /* White icon on hover */
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+  transform: translateY(-3px); /* Slight lift on hover */
+}
+
+/* Styles for the SVG icon inside the button */
+.back-to-top-button svg {
+  width: 24px;
+  height: 24px;
+}

--- a/src/BackToTopButton.js
+++ b/src/BackToTopButton.js
@@ -1,0 +1,58 @@
+// src/BackToTopButton.js
+
+import React, { useState, useEffect } from 'react'
+import './BackToTopButton.css' // Import our new styles
+
+const BackToTopButton = () => {
+  // 1. State to track whether the button should be visible
+  const [isVisible, setIsVisible] = useState(false)
+
+  // 2. A function to check the scroll position and update the state
+  const toggleVisibility = () => {
+    // Show the button if the user has scrolled down more than 300px
+    if (window.scrollY > 300) {
+      setIsVisible(true)
+    } else {
+      setIsVisible(false)
+    }
+  }
+
+  // 3. A function to scroll the window back to the top smoothly
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth', // This provides the smooth scrolling animation
+    })
+  }
+
+  // 4. Set up an effect to listen for scroll events
+  useEffect(() => {
+    // Add the event listener when the component mounts
+    window.addEventListener('scroll', toggleVisibility)
+
+    // Clean up the event listener when the component unmounts
+    // This is crucial to prevent memory leaks!
+    return () => {
+      window.removeEventListener('scroll', toggleVisibility)
+    }
+  }, []) // The empty array ensures this effect runs only once
+
+  return (
+    <button
+      className={`back-to-top-button ${isVisible ? 'visible' : ''}`}
+      onClick={scrollToTop}
+      aria-label="Go to top"
+    >
+      {/* A simple, inline SVG for the arrow icon */}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+      >
+        <path d="M12 4l8 8h-6v8h-4v-8H4l8-8z" />
+      </svg>
+    </button>
+  )
+}
+
+export default BackToTopButton


### PR DESCRIPTION
### Description

This pull request enhances the user experience on long pages by adding a "Back to Top" button. This button appears in the bottom-right corner of the screen after the user has scrolled down, providing a quick and smooth way to return to the top of the page.

### Key Changes:

*   **`BackToTopButton.js`**:
    *   Creates a new, self-contained component that manages its own state and logic.
    *   Uses `useState` and `useEffect` to listen for `window.scroll` events and determines its own visibility. The button is only shown after the user scrolls down 300px.
    *   Implements a `scrollToTop` function that uses `window.scrollTo({ behavior: 'smooth' })` for a pleasant scrolling animation.

*   **`BackToTopButton.css`**:
    *   Adds styles to position the button in the bottom-right corner and style it consistently with the application's theme.
    *   Includes a `transition` and an opacity toggle (`.visible` class) to create a smooth fade-in/fade-out effect as the button appears and disappears.

*   **`App.js`**:
    *   The new `BackToTopButton` component is imported and placed at the top level of the app, ensuring it is available on all pages.

### How to Test:

1.  Log into the application and navigate to the user dashboard page.
2.  The "Back to Top" button should **not** be visible initially.
3.  Scroll down the page past the first few widgets.
4.  **Expected:** The button should smoothly fade in and appear in the bottom-right corner.
5.  Click the "Back to Top" button.
6.  **Expected:** The page should smoothly scroll back to the very top.
7.  Once at the top, the button should smoothly fade out and disappear.