### PR TITLE
feat(ui): add role/team subheader and github username to widgets

### DIFF
--- a/src/DashboardPage.js
+++ b/src/DashboardPage.js
@@ -25,7 +25,18 @@ function DashboardPage({
   return (
     <div>
       <header className="app-header">
-        <h1>Welcome, {user.display_name}!</h1>
+        <div>
+          <h1>Welcome, {user.display_name}!</h1>
+          <p
+            style={{
+              margin: "0.25rem 0 0 0",
+              color: "var(--color-text-secondary)",
+              fontSize: "1rem",
+            }}
+          >
+            {user.role} - {user.team}
+          </p>
+        </div>
         <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
           <CounterButton
             label="Logout"
@@ -263,7 +274,7 @@ function DashboardPage({
 
         {/* --- GitHub PRs Widget --- */}
         <div className="widget-card">
-          <GitHubPRList pullRequests={userPullRequests} />
+          <GitHubPRList user={user} pullRequests={userPullRequests} />
         </div>
 
         {/* --- Edit Profile & Summary Aggregator Widgets --- */}

--- a/src/GitHubPRList.js
+++ b/src/GitHubPRList.js
@@ -3,7 +3,7 @@
 // 1. Import useState to manage which PRs are expanded
 import React, { useState } from "react";
 
-const GitHubPRList = ({ pullRequests }) => {
+const GitHubPRList = ({ user, pullRequests }) => {
   // 2. State to track the IDs of expanded PRs
   const [expandedPRs, setExpandedPRs] = useState({});
 
@@ -19,7 +19,10 @@ const GitHubPRList = ({ pullRequests }) => {
     return (
       <div>
         <div className="widget-header">
-          <h2>GitHub Pull Requests</h2>
+          <h2>
+            GitHub Pull Requests
+            {user.github_username && ` - ${user.github_username}`}
+          </h2>
         </div>
         <p>No pull requests found for this user.</p>
       </div>
@@ -29,7 +32,10 @@ const GitHubPRList = ({ pullRequests }) => {
   return (
     <div>
       <div className="widget-header">
-        <h2>GitHub Pull Requests</h2>
+        <h2>
+          GitHub Pull Requests
+          {user.github_username && ` - ${user.github_username}`}
+        </h2>
       </div>
       <div className="widget-scroll-container">
         <ul style={{ listStyle: "none", padding: 0 }}>


### PR DESCRIPTION
### Description

This pull request adds valuable contextual information to the user dashboard header and the GitHub Pull Requests widget, making the UI more personalized and informative at a glance.

### Key Changes:

*   **`DashboardPage.js`**:
    *   The main dashboard header has been updated to include a sub-header.
    *   Directly below the "Welcome, [User]!" message, it now displays the user's `Role` and `Team` (e.g., "Engineer - ENGINEERING").

*   **`GitHubPRList.js`**:
    *   The `user` object is now passed as a prop to this component.
    *   The widget header has been updated to conditionally display the user's GitHub username if it exists (e.g., "GitHub Pull Requests - robertplaut"). This provides immediate clarity on which account's data is being shown.

### How to Test:

1.  Log in as any user and navigate to their dashboard.
2.  **Test Dashboard Sub-header:**
    *   **Expected:** Observe the main sticky header. Below the "Welcome" message, you should see the user's role and team displayed in a smaller, secondary text style.
3.  **Test GitHub Widget Header:**
    *   **If the user has a GitHub username:** The header for the "GitHub Pull Requests" widget should now include their username.
    *   **If the user does NOT have a GitHub username:** The header should simply read "GitHub Pull Requests" without any extra text.