### PR TITLE
fix(build): remove unused react import in toastcontext

### DIFF
--- a/src/ToastContext.js
+++ b/src/ToastContext.js
@@ -1,17 +1,17 @@
 // src/ToastContext.js
 
-import React, { createContext, useContext } from 'react'
+import { createContext, useContext } from "react";
 
 // 1. Create the context with a default value.
 // The `addToast` function will be provided by our ToastProvider.
 const ToastContext = createContext({
   addToast: () => {}, // Default to an empty function
-})
+});
 
 // 2. Create a custom hook for easy consumption of the context.
 // Any component that calls `useToast()` will get access to the `addToast` function.
 export const useToast = () => {
-  return useContext(ToastContext)
-}
+  return useContext(ToastContext);
+};
 
-export default ToastContext
+export default ToastContext;


### PR DESCRIPTION
### Description

This PR resolves a critical build failure on Netlify. The Netlify CI/CD environment is configured by default to treat all linting warnings as errors, which was causing the deployment to fail.

The root cause was an unused `React` import in `src/ToastContext.js` that was missed during previous refactoring.

### Key Changes

*   **`src/ToastContext.js`**: Removed the unused `React` object from the import statement to resolve the `no-unused-vars` linting error.

### How to Test

1.  Merge this Pull Request into the `main` branch.
2.  Trigger a new deployment on Netlify from the `main` branch.
3.  Verify that the build and deployment process completes successfully.