### PR TITLE
style(ui): always show blue glow around date input field

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -254,3 +254,11 @@ hr {
   padding: 0.25rem 0.75rem;
   font-size: 0.875rem;
 }
+
+/* Always-highlighted style for the date input */
+input[type="date"] {
+  border: 1px solid rgba(81, 203, 238, 1);
+  box-shadow: 0 0 6px rgba(81, 203, 238, 1);
+  background-color: #ffffff;
+  transition: all 0.3s ease-in-out;
+}


### PR DESCRIPTION
## ✅ Pull Request: `style/always-highlight-date-input`

### Description

This PR enhances the user interface of the Daily Standup Note widget by making the calendar date input field visually distinct. Instead of applying the blue highlight only on focus, the new style ensures the field is always visually highlighted to improve visibility and form clarity.

---

### Key Changes

- **`src/App.css`**
  - Updated `input[type="date"]` selector to apply a persistent blue `box-shadow` and border style
  - Ensures the date input field always stands out in the form, regardless of focus state

---

### How to Test

1. Run the app locally using `netlify dev` or `npm start`
2. Navigate to the user dashboard (`/user/{your-username}`)
3. Look for the **Daily Standup Note** widget
4. Confirm that the **calendar date field** now:
   - Has a solid blue border
   - Has a soft blue glow around it
   - This styling is present even when the field is not focused
