### PR TITLE
feat(tour): implement smart positioning for popover with Floating UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "echostatus",
       "version": "2.2.0",
       "dependencies": {
+        "@floating-ui/react": "^0.27.13",
         "@reactour/popover": "^1.3.0",
         "@reactour/tour": "^3.8.0",
         "@supabase/supabase-js": "^2.50.3",
@@ -2460,6 +2461,59 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.2.tgz",
+      "integrity": "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.2.tgz",
+      "integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.2",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.13.tgz",
+      "integrity": "sha512-Qmj6t9TjgWAvbygNEu1hj4dbHI9CY0ziCMIJrmYoDIn9TUAH5lRmiIeZmRd4c6QEZkzdoH7jNnoNyoY1AIESiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.4",
+        "@floating-ui/utils": "^0.2.10",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.4.tgz",
+      "integrity": "sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -16133,6 +16187,12 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
       "license": "MIT"
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.2.0",
   "private": true,
   "dependencies": {
+    "@floating-ui/react": "^0.27.13",
     "@reactour/popover": "^1.3.0",
     "@reactour/tour": "^3.8.0",
     "@supabase/supabase-js": "^2.50.3",

--- a/src/App.js
+++ b/src/App.js
@@ -175,10 +175,7 @@ const Tour = () => {
   // These hooks add accessibility features and allow closing by clicking outside.
   const dismiss = useDismiss(context);
   const role = useRole(context);
-  const { getReferenceProps, getFloatingProps } = useInteractions([
-    dismiss,
-    role,
-  ]);
+  const { getFloatingProps } = useInteractions([dismiss, role]);
 
   useLayoutEffect(() => {
     if (isTourOpen && currentStep) {


### PR DESCRIPTION
### Description

This pull request significantly enhances our custom-built tour component by integrating the `@floating-ui/react` library. The primary goal of this update is to solve an issue where the tour popover could render off-screen when attached to elements near the viewport edges (especially tall elements).

With this change, the tour popover is now "smart." It automatically calculates the best position (`bottom`, `top`, `right`, or `left`) to ensure it remains fully visible to the user at all times, providing a more robust and professional user experience.

### Key Changes

*   **Dependency Installation:**
    *   Added `@floating-ui/react` to `package.json`.

*   **Tour Component Refactor (`src/App.js`):**
    *   Replaced the manual position calculation logic within the `<Tour />` component with the `useFloating` hook.
    *   Implemented middleware from Floating UI:
        *   `offset()`: To provide consistent spacing between the target element and the popover.
        *   `flip()`: To automatically change the popover's placement (e.g., from `bottom` to `top`, `right`, or `left`) if it runs out of space.
        *   `shift()`: To nudge the popover into view if it overflows the viewport on the cross-axis.
    *   Replaced the `useState` for the target element with `useRef` to provide a stable, immediate reference for the `useFloating` hook, fixing a subtle lifecycle bug.
    *   Modified the `scrollIntoView` behavior to use `block: "nearest"` for a less aggressive and more intelligent scrolling experience.
    *   Integrated accessibility helpers from Floating UI like `FloatingFocusManager` and `useDismiss` to improve usability.

### How to Test

1.  Log in as any user to navigate to the dashboard page.
2.  Start the dashboard tour by clicking the question-mark icon.
3.  **Test the first step:**
    *   The "Daily Standup Note" widget is very tall.
    *   **Expected Result:** The popover should now appear to the **right** or **left** of the widget, not partially cut off at the bottom.
4.  **Test the last step:**
    *   Navigate to the final step of the tour (the "AI Summary" widget), which is at the bottom of the page.
    *   **Expected Result:** The popover should intelligently "flip" and appear **above** the widget, not below it where it would be off-screen.
5.  Resize your browser window to be more narrow and restart the tour. Confirm that the popover continues to reposition itself to stay within the smaller viewport.